### PR TITLE
Edit: TabController::restore - checks if it's bundle is obtained from…

### DIFF
--- a/TabController/sample/src/main/java/com/appolica/sample/TabControllerFragmentActivity.java
+++ b/TabController/sample/src/main/java/com/appolica/sample/TabControllerFragmentActivity.java
@@ -35,9 +35,7 @@ public class TabControllerFragmentActivity
         tabController = tabControllerFragment.getTabController();
         tabController.setChangeListener(this);
 
-        if (savedInstanceState != null) {
-            tabController.restore(savedInstanceState);
-        } else {
+        if (savedInstanceState == null) {
             tabController.switchTo(Tabs.TAB_1);
         }
     }
@@ -77,9 +75,4 @@ public class TabControllerFragmentActivity
         Log.d(TAG, "onFragmentCreated: " + fragmentType.getTag());
     }
 
-    @Override
-    public void onSaveInstanceState(Bundle outState, PersistableBundle outPersistentState) {
-        super.onSaveInstanceState(outState, outPersistentState);
-        tabController.save(outState);
-    }
 }

--- a/TabController/tab-controller/src/main/java/com/appolica/tabcontroller/TabController.java
+++ b/TabController/tab-controller/src/main/java/com/appolica/tabcontroller/TabController.java
@@ -122,6 +122,11 @@ public class TabController {
     public void restore(@Nullable Bundle savedInstanceState) {
         if (savedInstanceState != null) {
             final Bundle controllerState = savedInstanceState.getBundle(BUNDLE_KEY);
+
+            if (controllerState == null) {
+                throw new IllegalStateException("TabController's bundle not found in savedInstanceState. Did you call TabController::save in onSaveInstanceState(outState)?");
+            }
+
             final List<Fragment> fragments = getFMFragments();
 
             inTransaction(transaction -> {

--- a/TabController/tab-controller/src/main/java/com/appolica/tabcontroller/fragment/TabControllerFragment.java
+++ b/TabController/tab-controller/src/main/java/com/appolica/tabcontroller/fragment/TabControllerFragment.java
@@ -29,6 +29,16 @@ public class TabControllerFragment extends Fragment {
         super.onViewCreated(view, savedInstanceState);
 
         tabController = new TabController(getChildFragmentManager(), R.id.container);
+
+        if (savedInstanceState != null) {
+            tabController.restore(savedInstanceState);
+        }
+    }
+
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        tabController.save(outState);
     }
 
     public TabController getTabController() {


### PR DESCRIPTION
… the saved instance state and throws exception if not. Ensures that TabController::save has been called in onSaveInstanceState.

Edit: TabControllerFragment.java - calls TabController::save in onSaveInstanceState and TabController::restore in onCreate if savedInstanceState != null. There is no need of the consumer of this fragment to be concerned about state restoration when using TabControllerFragment.