### PR TITLE
Changed implementation of isVisible in AttachDetachHandler

### DIFF
--- a/TabController/tab-controller/src/main/java/com/appolica/tabcontroller/AttachDetachHandler.java
+++ b/TabController/tab-controller/src/main/java/com/appolica/tabcontroller/AttachDetachHandler.java
@@ -37,6 +37,6 @@ public class AttachDetachHandler implements ShowHideHandler {
 
     @Override
     public boolean isVisible(Fragment fragment) {
-        return fragment.isVisible();
+        return !fragment.isDetached();
     }
 }

--- a/TabController/tab-controller/src/main/java/com/appolica/tabcontroller/ShowHideFrHandler.java
+++ b/TabController/tab-controller/src/main/java/com/appolica/tabcontroller/ShowHideFrHandler.java
@@ -18,13 +18,12 @@ public class ShowHideFrHandler implements ShowHideHandler {
 
     @Override
     public FragmentTransaction hide(FragmentTransaction transaction, Fragment fragment) {
-
         return transaction.hide(fragment);
     }
 
     @Override
     public void save(Bundle saveControllerState, Fragment fragment) {
-        boolean visible = !fragment.isHidden();
+        boolean visible = isVisible(fragment);
         saveControllerState.putBoolean(fragment.getTag(), visible);
     }
 


### PR DESCRIPTION
Edit: AttachDetachHandler.java - using !fragment.isDetached()  to determine if the given fragment is visible. isVisible() is not reliable enough

Edit: ShowHideFrHandler.java - Calling isVisible() in save() instead of implementing it again.